### PR TITLE
Update minecraft versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.shadow)
 }
 
-val baseVersion = "0.0.1"
+val baseVersion = "0.0.2"
 val commitHash = System.getenv("COMMIT_HASH")
 val snapshotversion = "${baseVersion}-dev.$commitHash"
 

--- a/proxy-bungeecord/build.gradle.kts
+++ b/proxy-bungeecord/build.gradle.kts
@@ -46,7 +46,11 @@ modrinth {
         "1.21.1",
         "1.21.2",
         "1.21.3",
-        "1.21.4"
+        "1.21.4",
+        "1.21.5",
+        "1.21.6",
+        "1.21.7",
+        "1.21.8"
     )
     loaders.add("bungeecord")
     changelog.set("https://docs.simplecloud.app/changelog")

--- a/proxy-velocity/build.gradle.kts
+++ b/proxy-velocity/build.gradle.kts
@@ -45,7 +45,11 @@ modrinth {
         "1.21.1",
         "1.21.2",
         "1.21.3",
-        "1.21.4"
+        "1.21.4",
+        "1.21.5",
+        "1.21.6",
+        "1.21.7",
+        "1.21.8"
     )
     loaders.add("velocity")
     changelog.set("https://docs.simplecloud.app/changelog")


### PR DESCRIPTION
This pull request updates the supported versions for the `modrinth` configuration in both the `proxy-bungeecord` and `proxy-velocity` modules. The changes ensure compatibility with newer versions.

Version updates:

* [`proxy-bungeecord/build.gradle.kts`](diffhunk://#diff-aae35bc3748c2cf3e63e21b24dc8cb817b44f0ed246b35dfd1ae2fbd95ee1211L49-R53): Added support for versions `1.21.5` through `1.21.8` in the `modrinth` configuration.
* [`proxy-velocity/build.gradle.kts`](diffhunk://#diff-2274d36057b0a31ff7a634d77daaa9bc7ec8f2237c2ea88ac0a7d00f3ad97200L48-R52): Added support for versions `1.21.5` through `1.21.8` in the `modrinth` configuration.