### PR TITLE
fixed: MiniMessage formatting for command (bungeecord)

### DIFF
--- a/proxy-bungeecord/src/main/kotlin/app/simplecloud/plugin/proxy/bungeecord/BungeeCordCommandSender.kt
+++ b/proxy-bungeecord/src/main/kotlin/app/simplecloud/plugin/proxy/bungeecord/BungeeCordCommandSender.kt
@@ -1,11 +1,14 @@
 package app.simplecloud.plugin.proxy.bungeecord
 
 import app.simplecloud.plugin.proxy.shared.handler.command.CommandSender
+import net.kyori.adventure.platform.bungeecord.BungeeAudiences
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.minimessage.MiniMessage
 import net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer
 import net.md_5.bungee.api.chat.BaseComponent
 
-class BungeeCordCommandSender(private val commandSender: net.md_5.bungee.api.CommandSender
+class BungeeCordCommandSender(private val commandSender: net.md_5.bungee.api.CommandSender,
+                              private val adventure: BungeeAudiences?
 ) : CommandSender {
 
     fun getCommandSender(): net.md_5.bungee.api.CommandSender {
@@ -13,7 +16,7 @@ class BungeeCordCommandSender(private val commandSender: net.md_5.bungee.api.Com
     }
 
     override fun sendMessage(message: String) {
-        commandSender.sendMessage(message)
+        adventure?.sender(commandSender)?.sendMessage(MiniMessage.miniMessage().deserialize(message))
     }
 }
 

--- a/proxy-bungeecord/src/main/kotlin/app/simplecloud/plugin/proxy/bungeecord/ProxyBungeeCordPlugin.kt
+++ b/proxy-bungeecord/src/main/kotlin/app/simplecloud/plugin/proxy/bungeecord/ProxyBungeeCordPlugin.kt
@@ -49,7 +49,7 @@ class ProxyBungeeCordPlugin: Plugin() {
         val executionCoordinator = ExecutionCoordinator.simpleCoordinator<CommandSender>()
 
         val senderMapper = SenderMapper.create<net.md_5.bungee.api.CommandSender, CommandSender>(
-            { commandSender -> BungeeCordCommandSender(commandSender) },
+            { commandSender -> BungeeCordCommandSender(commandSender, adventure) },
             { cloudSender -> (cloudSender as BungeeCordCommandSender).getCommandSender() }
         )
 


### PR DESCRIPTION
This pull request updates the command sender implementation for BungeeCord to use the Adventure API for message handling, enabling support for rich text formatting via MiniMessage. The main changes involve passing the `BungeeAudiences` instance to the `BungeeCordCommandSender` and updating how messages are sent to users.

**Adventure API integration:**

* Updated the `BungeeCordCommandSender` class to accept a `BungeeAudiences` instance and use it to send messages with MiniMessage deserialization, allowing for advanced text formatting.
* Modified the sender mapping in `ProxyBungeeCordPlugin` to pass the `adventure` instance when constructing `BungeeCordCommandSender`.