### PR TITLE
Fix join state checks for server switches

### DIFF
--- a/proxy-bungeecord/src/main/kotlin/app/simplecloud/plugin/proxy/bungeecord/listener/ServerPreConnectListener.kt
+++ b/proxy-bungeecord/src/main/kotlin/app/simplecloud/plugin/proxy/bungeecord/listener/ServerPreConnectListener.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.runBlocking
 import net.md_5.bungee.api.config.ServerInfo
 import net.md_5.bungee.api.connection.ProxiedPlayer
 import net.md_5.bungee.api.event.ServerConnectEvent
+import net.md_5.bungee.api.event.ServerConnectEvent.Reason
 import net.md_5.bungee.api.plugin.Listener
 import net.md_5.bungee.event.EventHandler
 import net.md_5.bungee.event.EventPriority
@@ -19,11 +20,18 @@ class ServerPreConnectListener(
 
     @EventHandler(priority = EventPriority.HIGH)
     fun handle(event: ServerConnectEvent) {
-        checkAllowProxyJoin(event.player, event)
-        if (event.isCancelled) {
-            return
+        if (isProxyJoin(event)) {
+            checkAllowProxyJoin(event.player, event)
+            if (event.isCancelled) {
+                return
+            }
         }
+
         checkAllowServerSwitch(event.player, event, event.target)
+    }
+
+    private fun isProxyJoin(event: ServerConnectEvent): Boolean {
+        return event.reason == Reason.JOIN_PROXY || event.player.server == null
     }
 
     private fun checkAllowProxyJoin(player: ProxiedPlayer, event: ServerConnectEvent) {

--- a/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/handler/JoinStateResolver.kt
+++ b/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/handler/JoinStateResolver.kt
@@ -13,6 +13,7 @@ class JoinStateResolver(
     private val identifier by lazy {
         ServerPatternIdentifier(
             "<group_name>-<numerical_id>",
+            "(?<groupName>[a-zA-Z0-9_-]+)-(?<numericalId>\\d+)",
             cloudApi = proxyPlugin.api
         )
     }

--- a/proxy-velocity/src/main/kotlin/app/simplecloud/plugin/proxy/velocity/listener/ServerPreConnectListener.kt
+++ b/proxy-velocity/src/main/kotlin/app/simplecloud/plugin/proxy/velocity/listener/ServerPreConnectListener.kt
@@ -19,10 +19,13 @@ class ServerPreConnectListener(
 
     @Subscribe(order = PostOrder.EARLY)
     fun handle(event: ServerPreConnectEvent) {
-        checkAllowProxyJoin(event.player, event)
-        if (event.result.isAllowed.not()) {
-            return
+        if (event.previousServer == null) {
+            checkAllowProxyJoin(event.player, event)
+            if (event.result.isAllowed.not()) {
+                return
+            }
         }
+
         checkAllowServerSwitch(event.player, event, event.originalServer)
     }
 
@@ -67,7 +70,7 @@ class ServerPreConnectListener(
             }
 
             if (joinState.permission.join.isNotBlank() && !player.hasPermission(joinState.permission.join)) {
-                logger.info("Player ${player.username} does not have permission to join $serverName.")
+                logger.info("Player ${player.username} does not have permission to join $serverName. (JoinState: ${joinStateName}, Permission: ${joinState.permission.join})")
                 denyAccess(player, proxyPlugin.messagesConfiguration.get().kick.noPermission, true, event)
             }
         }


### PR DESCRIPTION
## Description
Players who were already connected to the proxy could be blocked while switching servers because the proxy-level join-state check ran for every server connect event, not only for the initial proxy join. That made maintenance/full-network checks apply again during normal server switches before the target server join-state check ran. Server names with hyphenated group names such as `cave-ffa-1` also failed the join-state service parser, so target service join states could be missed and fall back incorrectly.

## Changes
- Limit Velocity proxy join checks to the initial connection by checking `previousServer == null`.
- Limit BungeeCord proxy join checks to initial proxy joins using `JOIN_PROXY` or a missing current server.
- Keep target server join-state checks active for server switches.
- Allow join-state service parsing for group names containing letters, digits, underscores, and hyphens, so `cave-ffa-1` resolves to group `cave-ffa` and numerical id `1`.
- Include the resolved join state and required permission in the Velocity denial log for easier diagnosis.

## Type of Change
- [ ] New feature / capability
- [x] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Behavior Change

**Before:**
Proxy-level join-state and full-network checks ran again during server switches, and hyphenated service names like `cave-ffa-1` did not parse as `<group>-<id>`.

**After:**
Proxy-level join-state checks run only on initial proxy join, target server join-state checks still run on switches, and `cave-ffa-1` resolves to the `cave-ffa` service with numerical id `1`.

## Pre-Deployment Migrations
No migrations required before deploying.