### PR TITLE
Add Player Count support with configurable intervals and integration

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - develop
   workflow_dispatch:
 
 jobs:
@@ -16,7 +15,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: develop  # Ensure it works from the develop branch
+          ref: main
 
       - name: Set up JDK 21
         uses: actions/setup-java@v3
@@ -51,20 +50,19 @@ jobs:
       - name: Publish to Modrinth
         run: ./gradlew modrinth && ./gradlew modrinthSyncBody
         env:
-          COMMIT_HASH: ${{ env.COMMIT_HASH }}
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
 
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
         with:
-          tag_name: v${{ env.GRADLE_VERSION }}-dev.${{ env.COMMIT_HASH }}
-          release_name: v${{ env.GRADLE_VERSION }}-dev.${{ env.COMMIT_HASH }}
+          tag_name: v${{ env.GRADLE_VERSION }}
+          release_name: v${{ env.GRADLE_VERSION }}
           draft: false
-          prerelease: true
-          commitish: develop
+          prerelease: false
+          commitish: main
           body: |
-            This release contains dev builds for all Gradle modules.
+            This release contains release builds for all Gradle modules.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -77,7 +75,7 @@ jobs:
               echo "Skipping $jar due to version number"
             else
               echo "Uploading $jar"
-              gh release upload v${{ env.GRADLE_VERSION }}-dev.${{ env.COMMIT_HASH }} "$jar"
+              gh release upload v${{ env.GRADLE_VERSION }} "$jar"
             fi
           done
         env:

--- a/proxy-bungeecord/build.gradle.kts
+++ b/proxy-bungeecord/build.gradle.kts
@@ -24,7 +24,7 @@ modrinth {
     token.set(project.findProperty("modrinthToken") as String? ?: System.getenv("MODRINTH_TOKEN"))
     projectId.set("WzfN2mLK")
     versionNumber.set(rootProject.version.toString())
-    versionType.set("beta")
+    versionType.set("release")
     uploadFile.set(tasks.shadowJar)
     gameVersions.addAll(
         

--- a/proxy-bungeecord/src/main/kotlin/app/simplecloud/plugin/proxy/bungeecord/listener/ConfigureTagResolversListener.kt
+++ b/proxy-bungeecord/src/main/kotlin/app/simplecloud/plugin/proxy/bungeecord/listener/ConfigureTagResolversListener.kt
@@ -17,8 +17,9 @@ class ConfigureTagResolversListener(
         val serverName = player?.server?.info?.name ?: "unknown"
         val ping = player?.ping ?: -1
         val pingColors = plugin.proxyPlugin.placeHolderConfiguration.get().pingColors
-        val onlinePlayers = plugin.proxy.players.size
-        val realMaxPlayers = plugin.proxy.config.playerLimit
+        val playerCountHandler = plugin.proxyPlugin.playerCountHandler
+        val onlinePlayers = playerCountHandler.onlinePlayersOr(plugin.proxy.players.size)
+        val realMaxPlayers = playerCountHandler.maxPlayersOr(plugin.proxy.config.playerLimit)
 
         event.withTagResolvers(
             TagResolverHelper.getDefaultTagResolvers(

--- a/proxy-bungeecord/src/main/kotlin/app/simplecloud/plugin/proxy/bungeecord/listener/ProxyPingListener.kt
+++ b/proxy-bungeecord/src/main/kotlin/app/simplecloud/plugin/proxy/bungeecord/listener/ProxyPingListener.kt
@@ -54,15 +54,17 @@ class ProxyPingListener(
             }
 
             // slots
-            val onlinePlayers = response.players.online
+            val playerCountHandler = plugin.proxyPlugin.playerCountHandler
+            val onlinePlayers = playerCountHandler.onlinePlayersOr(response.players.online)
+            val realMax = playerCountHandler.maxPlayersOr(response.players.max)
             val maxPlayers = if (layout.versionSettings.slots.enabled) {
                 when (layout.versionSettings.slots.type) {
-                    MaxPlayerDisplayType.REAL -> response.players.max
+                    MaxPlayerDisplayType.REAL -> realMax
                     MaxPlayerDisplayType.FAKE -> layout.versionSettings.slots.fakeSlots
                     MaxPlayerDisplayType.DYNAMIC -> onlinePlayers + layout.versionSettings.slots.dynamicPlayerRange
                 }
             } else {
-                response.players.max
+                realMax
             }
 
             response.players = Players(maxPlayers, onlinePlayers, samplePlayers)

--- a/proxy-bungeecord/src/main/resources/config/config.yml
+++ b/proxy-bungeecord/src/main/resources/config/config.yml
@@ -33,6 +33,21 @@ whitelist:
     - Notch
 
 # ───────────────────────────────────────────────────────────────────────────────
+# Player Count
+# Displays the summed player count for this proxy group and optional extra targets.
+#
+# Read more @ https://docs.simplecloud.app/manual/plugins/proxy-essentials
+# ───────────────────────────────────────────────────────────────────────────────
+
+player-count:
+  # Additional SimpleCloud groups included in the displayed player count.
+  additional-groups: []
+  # Persistent servers included in the displayed player count.
+  additional-persistent-servers: []
+  # Player count update interval in ticks.
+  update-time: 20
+
+# ───────────────────────────────────────────────────────────────────────────────
 # Tablist
 # Configures tablist layouts and update intervals for connected players.
 #

--- a/proxy-bungeecord/src/main/resources/config/config.yml
+++ b/proxy-bungeecord/src/main/resources/config/config.yml
@@ -40,11 +40,13 @@ whitelist:
 # ───────────────────────────────────────────────────────────────────────────────
 
 player-count:
+  # Enables summed player counts for the server list and placeholders.
+  enabled: true
   # Additional SimpleCloud groups included in the displayed player count.
   additional-groups: []
   # Persistent servers included in the displayed player count.
   additional-persistent-servers: []
-  # Player count update interval in ticks.
+  # Player count update interval in ticks. Set to 0 to disable automatic updates.
   update-time: 20
 
 # ───────────────────────────────────────────────────────────────────────────────

--- a/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/ProxyPlugin.kt
+++ b/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/ProxyPlugin.kt
@@ -12,6 +12,7 @@ import app.simplecloud.plugin.proxy.shared.handler.CloudControllerHandler
 import app.simplecloud.plugin.proxy.shared.handler.JoinStateHandler
 import app.simplecloud.plugin.proxy.shared.handler.JoinStateResolver
 import app.simplecloud.plugin.proxy.shared.handler.MotdLayoutHandler
+import app.simplecloud.plugin.proxy.shared.handler.PlayerCountHandler
 import app.simplecloud.plugin.proxy.shared.handler.TabListResolver
 import java.io.File
 import java.nio.file.Path
@@ -36,10 +37,12 @@ class ProxyPlugin(
     val motdLayoutHandler = MotdLayoutHandler(File("$dirPath/layout").toPath(), this)
     val joinStateHandler = JoinStateHandler(this)
     val cloudControllerHandler = CloudControllerHandler(this, joinStateHandler)
+    val playerCountHandler = PlayerCountHandler(this).also { it.start() }
     val joinStateResolver = JoinStateResolver(this)
     val tabListResolver = TabListResolver { proxyEssentialsConfig.get().tablist }
 
     fun shutdown() {
+        playerCountHandler.stop()
         joinStateHandler.stop()
         cloudControllerHandler.close()
         motdLayoutHandler.close()

--- a/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/config/OldConfigMigrator.kt
+++ b/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/config/OldConfigMigrator.kt
@@ -21,6 +21,7 @@ object OldConfigMigrator {
         Files.createDirectories(dataDirectory)
 
         migrateMainConfig(dataDirectory)
+        ensureMainConfigDefaults(dataDirectory.resolve("config.yml"))
         migrateMessages(dataDirectory.resolve("messages.yml"))
         migratePlaceholder(dataDirectory.resolve("placeholder.yml"))
         migrateLayouts(dataDirectory.resolve("layout"))
@@ -55,6 +56,29 @@ object OldConfigMigrator {
         target.writeCommentedYaml(::decorateMainConfigYaml)
         deleteIfExists(joinStateFile)
         deleteIfExists(tabListFile)
+    }
+
+    private fun ensureMainConfigDefaults(target: Path) {
+        if (!Files.exists(target)) return
+
+        val loader = createLoader(target)
+        val node = loader.load()
+        val playerCountNode = node.node("player-count")
+        var changed = false
+
+        if (playerCountNode.virtual()) {
+            playerCountNode.set(defaultPlayerCount())
+            changed = true
+        } else if (playerCountNode.node("enabled").virtual()) {
+            playerCountNode.node("enabled").set(ProxyEssentialsConfig().playerCount.enabled)
+            changed = true
+        }
+
+        if (!changed) return
+
+        node.applyMainConfigComments()
+        loader.save(node)
+        target.writeCommentedYaml(::decorateMainConfigYaml)
     }
 
     private fun CommentedConfigurationNode.containsMigratedMainConfig(
@@ -438,9 +462,10 @@ object OldConfigMigrator {
         node("whitelist").comment(WHITELIST_COMMENT)
         node("whitelist", "players").comment("Supports player names and UUIDs.")
         node("player-count").comment(PLAYER_COUNT_COMMENT)
+        node("player-count", "enabled").comment("Enables summed player counts for the server list and placeholders.")
         node("player-count", "additional-groups").comment("Additional SimpleCloud groups included in the displayed player count.")
         node("player-count", "additional-persistent-servers").comment("Persistent servers included in the displayed player count.")
-        node("player-count", "update-time").comment("Player count update interval in ticks.")
+        node("player-count", "update-time").comment("Player count update interval in ticks. Set to 0 to disable automatic updates.")
         node("tablist").comment(TABLIST_COMMENT)
         node("tablist").childrenList().forEach { group ->
             group.node("update-time").comment("Update interval in ticks.")
@@ -497,6 +522,7 @@ object OldConfigMigrator {
     private fun defaultPlayerCount(): Map<String, Any> {
         val playerCount = ProxyEssentialsConfig().playerCount
         return mapOf(
+            "enabled" to playerCount.enabled,
             "additional-groups" to playerCount.additionalGroups,
             "additional-persistent-servers" to playerCount.additionalPersistentServers,
             "update-time" to playerCount.updateTime
@@ -521,9 +547,10 @@ object OldConfigMigrator {
             .insertBefore("whitelist:", WHITELIST_YAML_COMMENT)
             .insertBefore("    players:", "    # Supports player names and UUIDs.\n")
             .insertBefore("player-count:", PLAYER_COUNT_YAML_COMMENT)
+            .insertBeforeInSection("player-count:", "    enabled:", "    # Enables summed player counts for the server list and placeholders.\n")
             .insertBeforeInSection("player-count:", "    additional-groups:", "    # Additional SimpleCloud groups included in the displayed player count.\n")
             .insertBeforeInSection("player-count:", "    additional-persistent-servers:", "    # Persistent servers included in the displayed player count.\n")
-            .insertBeforeInSection("player-count:", "    update-time:", "    # Player count update interval in ticks.\n")
+            .insertBeforeInSection("player-count:", "    update-time:", "    # Player count update interval in ticks. Set to 0 to disable automatic updates.\n")
             .insertBefore("tablist:", TABLIST_YAML_COMMENT)
             .insertBeforeInSection("tablist:", "    update-time:", "    # Update interval in ticks.\n")
     }

--- a/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/config/OldConfigMigrator.kt
+++ b/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/config/OldConfigMigrator.kt
@@ -47,6 +47,7 @@ object OldConfigMigrator {
 
         node.node("version").set(CURRENT_CONFIG_VERSION)
         migrateJoinStates(joinStateNode, node)
+        node.node("player-count").set(defaultPlayerCount())
         migrateTabList(tabListNode, node)
         node.applyMainConfigComments()
 
@@ -436,6 +437,10 @@ object OldConfigMigrator {
         node("initial-state").comment(JOIN_STATES_COMMENT)
         node("whitelist").comment(WHITELIST_COMMENT)
         node("whitelist", "players").comment("Supports player names and UUIDs.")
+        node("player-count").comment(PLAYER_COUNT_COMMENT)
+        node("player-count", "additional-groups").comment("Additional SimpleCloud groups included in the displayed player count.")
+        node("player-count", "additional-persistent-servers").comment("Persistent servers included in the displayed player count.")
+        node("player-count", "update-time").comment("Player count update interval in ticks.")
         node("tablist").comment(TABLIST_COMMENT)
         node("tablist").childrenList().forEach { group ->
             group.node("update-time").comment("Update interval in ticks.")
@@ -489,6 +494,15 @@ object OldConfigMigrator {
         }
     }
 
+    private fun defaultPlayerCount(): Map<String, Any> {
+        val playerCount = ProxyEssentialsConfig().playerCount
+        return mapOf(
+            "additional-groups" to playerCount.additionalGroups,
+            "additional-persistent-servers" to playerCount.additionalPersistentServers,
+            "update-time" to playerCount.updateTime
+        )
+    }
+
     private fun Path.loadYaml(): CommentedConfigurationNode {
         return createLoader(this).load()
     }
@@ -506,8 +520,12 @@ object OldConfigMigrator {
             .insertBefore("initial-state:", JOIN_STATES_YAML_COMMENT)
             .insertBefore("whitelist:", WHITELIST_YAML_COMMENT)
             .insertBefore("    players:", "    # Supports player names and UUIDs.\n")
+            .insertBefore("player-count:", PLAYER_COUNT_YAML_COMMENT)
+            .insertBeforeInSection("player-count:", "    additional-groups:", "    # Additional SimpleCloud groups included in the displayed player count.\n")
+            .insertBeforeInSection("player-count:", "    additional-persistent-servers:", "    # Persistent servers included in the displayed player count.\n")
+            .insertBeforeInSection("player-count:", "    update-time:", "    # Player count update interval in ticks.\n")
             .insertBefore("tablist:", TABLIST_YAML_COMMENT)
-            .insertBefore("    update-time:", "    # Update interval in ticks.\n")
+            .insertBeforeInSection("tablist:", "    update-time:", "    # Update interval in ticks.\n")
     }
 
     private fun decorateLayoutYaml(content: String): String {
@@ -538,6 +556,22 @@ object OldConfigMigrator {
         return lines.joinToString("\n").trimEnd() + "\n"
     }
 
+    private fun String.insertBeforeInSection(sectionPrefix: String, linePrefix: String, comment: String): String {
+        if (comment.isEmpty() || contains(comment.trimEnd())) return this
+        val lines = lines().toMutableList()
+        val sectionIndex = lines.indexOfFirst { it.startsWith(sectionPrefix) }
+        if (sectionIndex == -1) return this
+
+        val relativeIndex = lines
+            .drop(sectionIndex + 1)
+            .indexOfFirst { it.startsWith(linePrefix) }
+        if (relativeIndex == -1) return this
+
+        val commentLines = comment.trimEnd().lines()
+        lines.addAll(sectionIndex + 1 + relativeIndex, commentLines)
+        return lines.joinToString("\n").trimEnd() + "\n"
+    }
+
     private fun createLoader(path: Path): YamlConfigurationLoader {
         return YamlConfigurationLoader.builder()
             .path(path)
@@ -562,6 +596,13 @@ object OldConfigMigrator {
         "Global whitelist for direct player access.\n" +
             "Prefer permission-based access for regular users.\n" +
             "Use this list only for administrators or emergency access."
+
+    private const val PLAYER_COUNT_COMMENT =
+        "───────────────────────────────────────────────────────────────────────────────\n" +
+            "Player Count\n" +
+            "Displays the summed player count for this proxy group and optional extra targets.\n\n" +
+            "Read more @ https://docs.simplecloud.app/manual/plugins/proxy-essentials\n" +
+            "───────────────────────────────────────────────────────────────────────────────"
 
     private const val TABLIST_COMMENT =
         "───────────────────────────────────────────────────────────────────────────────\n" +
@@ -609,6 +650,14 @@ object OldConfigMigrator {
         "\n# Global whitelist for direct player access.\n" +
             "# Prefer permission-based access for regular users.\n" +
             "# Use this list only for administrators or emergency access.\n"
+
+    private const val PLAYER_COUNT_YAML_COMMENT =
+        "\n# ───────────────────────────────────────────────────────────────────────────────\n" +
+            "# Player Count\n" +
+            "# Displays the summed player count for this proxy group and optional extra targets.\n" +
+            "#\n" +
+            "# Read more @ https://docs.simplecloud.app/manual/plugins/proxy-essentials\n" +
+            "# ───────────────────────────────────────────────────────────────────────────────\n"
 
     private const val TABLIST_YAML_COMMENT =
         "\n# ───────────────────────────────────────────────────────────────────────────────\n" +

--- a/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/config/PlayerCountConfig.kt
+++ b/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/config/PlayerCountConfig.kt
@@ -1,0 +1,11 @@
+package app.simplecloud.plugin.proxy.shared.config
+
+import org.spongepowered.configurate.objectmapping.ConfigSerializable
+import org.spongepowered.configurate.objectmapping.meta.Setting
+
+@ConfigSerializable
+data class PlayerCountConfig(
+    @Setting("additional-groups") val additionalGroups: List<String> = emptyList(),
+    @Setting("additional-persistent-servers") val additionalPersistentServers: List<String> = emptyList(),
+    @Setting("update-time") val updateTime: Long = 20L
+)

--- a/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/config/PlayerCountConfig.kt
+++ b/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/config/PlayerCountConfig.kt
@@ -5,6 +5,7 @@ import org.spongepowered.configurate.objectmapping.meta.Setting
 
 @ConfigSerializable
 data class PlayerCountConfig(
+    val enabled: Boolean = true,
     @Setting("additional-groups") val additionalGroups: List<String> = emptyList(),
     @Setting("additional-persistent-servers") val additionalPersistentServers: List<String> = emptyList(),
     @Setting("update-time") val updateTime: Long = 20L

--- a/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/config/ProxyEssentialsConfig.kt
+++ b/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/config/ProxyEssentialsConfig.kt
@@ -25,6 +25,7 @@ data class ProxyEssentialsConfig(
         )
     ),
     val whitelist: WhitelistConfig = WhitelistConfig(),
+    @Setting("player-count") val playerCount: PlayerCountConfig = PlayerCountConfig(),
     val tablist: List<TabListGroup> = listOf(
         TabListGroup(
             name = "global",
@@ -36,5 +37,9 @@ data class ProxyEssentialsConfig(
     fun tabListUpdateTimeMillis(): Long {
         val ticks = tablist.minOfOrNull { it.updateTime } ?: 20L
         return ticks * 50L
+    }
+
+    fun playerCountUpdateTimeMillis(): Long {
+        return playerCount.updateTime.coerceAtLeast(1L) * 50L
     }
 }

--- a/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/config/ProxyEssentialsConfig.kt
+++ b/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/config/ProxyEssentialsConfig.kt
@@ -39,7 +39,11 @@ data class ProxyEssentialsConfig(
         return ticks * 50L
     }
 
-    fun playerCountUpdateTimeMillis(): Long {
-        return playerCount.updateTime.coerceAtLeast(1L) * 50L
+    fun playerCountUpdateTimeMillis(): Long? {
+        if (!playerCount.enabled || playerCount.updateTime <= 0L) {
+            return null
+        }
+
+        return playerCount.updateTime * 50L
     }
 }

--- a/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/handler/CloudControllerHandler.kt
+++ b/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/handler/CloudControllerHandler.kt
@@ -113,6 +113,13 @@ class CloudControllerHandler(
         null
     }
 
+    suspend fun getServerById(serverId: String): Server? = try {
+        plugin.api.server().getServerById(serverId).await()
+    } catch (e: Exception) {
+        logger.severe("Error retrieving server by ID '$serverId': ${e.message}")
+        null
+    }
+
     suspend fun getServersByGroup(groupName: String): List<Server> = try {
         plugin.api.server().getAllServers(
             ServerQuery.create()
@@ -196,6 +203,20 @@ class CloudControllerHandler(
         } catch (e: Exception) {
             logger.severe("Error retrieving server by name: ${e.message}")
             null
+        }
+    }
+
+    suspend fun getPersistentServersByNames(names: Set<String>): List<Server> {
+        if (names.isEmpty()) {
+            return emptyList()
+        }
+
+        return try {
+            val servers = plugin.api.server().getAllServers(ServerQuery.create()).await() ?: return emptyList()
+            servers.filter { server -> server.persistentServer?.name?.let { it in names } == true }
+        } catch (e: Exception) {
+            logger.severe("Error retrieving persistent servers by name: ${e.message}")
+            emptyList()
         }
     }
 }

--- a/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/handler/PlayerCountHandler.kt
+++ b/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/handler/PlayerCountHandler.kt
@@ -22,8 +22,15 @@ class PlayerCountHandler(
 
         syncJob = scope.launch {
             while (isActive) {
+                val updateTimeMillis = proxyPlugin.proxyEssentialsConfig.get().playerCountUpdateTimeMillis()
+                if (updateTimeMillis == null) {
+                    snapshot = null
+                    delay(DISABLED_CHECK_INTERVAL_MILLIS)
+                    continue
+                }
+
                 refresh()
-                delay(proxyPlugin.proxyEssentialsConfig.get().playerCountUpdateTimeMillis())
+                delay(updateTimeMillis)
             }
         }
     }
@@ -128,4 +135,8 @@ class PlayerCountHandler(
         val onlinePlayers: Int,
         val maxPlayers: Int?
     )
+
+    private companion object {
+        const val DISABLED_CHECK_INTERVAL_MILLIS = 1000L
+    }
 }

--- a/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/handler/PlayerCountHandler.kt
+++ b/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/handler/PlayerCountHandler.kt
@@ -1,0 +1,131 @@
+package app.simplecloud.plugin.proxy.shared.handler
+
+import app.simplecloud.api.server.Server
+import app.simplecloud.plugin.proxy.shared.ProxyPlugin
+import kotlinx.coroutines.*
+import java.util.logging.Logger
+
+class PlayerCountHandler(
+    private val proxyPlugin: ProxyPlugin
+) {
+    private val logger = Logger.getLogger(PlayerCountHandler::class.java.name)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var syncJob: Job? = null
+
+    @Volatile
+    private var snapshot: PlayerCountSnapshot? = null
+
+    fun start() {
+        if (syncJob?.isActive == true) {
+            return
+        }
+
+        syncJob = scope.launch {
+            while (isActive) {
+                refresh()
+                delay(proxyPlugin.proxyEssentialsConfig.get().playerCountUpdateTimeMillis())
+            }
+        }
+    }
+
+    fun stop() {
+        syncJob?.cancel()
+        scope.cancel()
+    }
+
+    fun onlinePlayersOr(fallback: Int): Int {
+        return snapshot?.onlinePlayers ?: fallback
+    }
+
+    fun maxPlayersOr(fallback: Int): Int {
+        return snapshot?.maxPlayers?.takeIf { it > 0 } ?: fallback
+    }
+
+    private suspend fun refresh() {
+        try {
+            snapshot = resolveSnapshot()
+        } catch (e: Exception) {
+            logger.severe("Error while syncing player count: ${e.message}")
+        }
+    }
+
+    private suspend fun resolveSnapshot(): PlayerCountSnapshot? {
+        val snapshots = resolveCountSnapshots()
+
+        if (snapshots.isEmpty()) {
+            return null
+        }
+
+        return PlayerCountSnapshot(
+            onlinePlayers = snapshots.sumOf { it.onlinePlayers },
+            maxPlayers = snapshots.sumOf { it.maxPlayers ?: 0 }.takeIf { it > 0 }
+        )
+    }
+
+    private suspend fun resolveCountSnapshots(): List<PlayerCountSnapshot> {
+        val currentServer = proxyPlugin.cloudControllerHandler.currentServer
+        val config = proxyPlugin.proxyEssentialsConfig.get().playerCount
+        val currentGroupName = currentServer
+            ?.takeIf { it.isFromGroup }
+            ?.group
+            ?.name
+        val currentPersistentServerName = currentServer
+            ?.takeIf { it.isFromPersistentServer }
+            ?.persistentServer
+            ?.name
+
+        val groupNames = (
+            listOfNotNull(currentGroupName) +
+                config.additionalGroups
+            )
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .distinct()
+        val groupSnapshots = groupNames.mapNotNull { resolveGroupSnapshot(it) }
+
+        val additionalPersistentServerNames = config.additionalPersistentServers
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .filter { it != currentPersistentServerName }
+            .toSet()
+        val persistentServerSnapshots = proxyPlugin.cloudControllerHandler
+            .getPersistentServersByNames(additionalPersistentServerNames)
+            .map { resolveServerSnapshot(it) }
+
+        return listOfNotNull(resolveCurrentServerSnapshot(currentServer)) + groupSnapshots + persistentServerSnapshots
+    }
+
+    private suspend fun resolveCurrentServerSnapshot(currentServer: Server?): PlayerCountSnapshot? {
+        if (currentServer == null || currentServer.isFromGroup) {
+            return null
+        }
+
+        val server = proxyPlugin.cloudControllerHandler.getServerById(currentServer.serverId) ?: currentServer
+        return resolveServerSnapshot(server)
+    }
+
+    private suspend fun resolveGroupSnapshot(groupName: String): PlayerCountSnapshot? {
+        val onlinePlayers = proxyPlugin.cloudControllerHandler.getOnlinePlayersInGroup(groupName)
+        val maxPlayers = proxyPlugin.cloudControllerHandler.getMaxPlayersInGroup(groupName)
+        if (onlinePlayers <= 0 && maxPlayers <= 0) {
+            return null
+        }
+
+        return PlayerCountSnapshot(
+            onlinePlayers = onlinePlayers,
+            maxPlayers = maxPlayers.takeIf { it > 0 }
+        )
+    }
+
+    private fun resolveServerSnapshot(server: Server): PlayerCountSnapshot {
+        return PlayerCountSnapshot(
+            onlinePlayers = server.playerCount?.toInt() ?: 0,
+            maxPlayers = server.maxPlayers?.toInt()?.takeIf { it > 0 }
+        )
+    }
+
+    private data class PlayerCountSnapshot(
+        val onlinePlayers: Int,
+        val maxPlayers: Int?
+    )
+}

--- a/proxy-velocity/build.gradle.kts
+++ b/proxy-velocity/build.gradle.kts
@@ -18,7 +18,7 @@ modrinth {
     token.set(project.findProperty("modrinthToken") as String? ?: System.getenv("MODRINTH_TOKEN"))
     projectId.set("WzfN2mLK")
     versionNumber.set(rootProject.version.toString())
-    versionType.set("beta")
+    versionType.set("release")
     uploadFile.set(tasks.shadowJar)
     gameVersions.addAll(
         "1.20",

--- a/proxy-velocity/src/main/kotlin/app/simplecloud/plugin/proxy/velocity/listener/ConfigureTagResolversListener.kt
+++ b/proxy-velocity/src/main/kotlin/app/simplecloud/plugin/proxy/velocity/listener/ConfigureTagResolversListener.kt
@@ -19,8 +19,9 @@ class ConfigureTagResolversListener(
         val serverName = player?.currentServer?.getOrNull()?.serverInfo?.name ?: "unknown"
         val ping = player?.ping ?: -1
         val pingColors = proxyPlugin.placeHolderConfiguration.get().pingColors
-        val onlinePlayers = plugin.proxyServer.allPlayers.size
-        val realMaxPlayers = plugin.proxyServer.configuration.showMaxPlayers
+        val playerCountHandler = proxyPlugin.playerCountHandler
+        val onlinePlayers = playerCountHandler.onlinePlayersOr(plugin.proxyServer.allPlayers.size)
+        val realMaxPlayers = playerCountHandler.maxPlayersOr(plugin.proxyServer.configuration.showMaxPlayers)
 
         event.withTagResolvers(
             TagResolverHelper.getDefaultTagResolvers(

--- a/proxy-velocity/src/main/kotlin/app/simplecloud/plugin/proxy/velocity/listener/ProxyPingListener.kt
+++ b/proxy-velocity/src/main/kotlin/app/simplecloud/plugin/proxy/velocity/listener/ProxyPingListener.kt
@@ -49,8 +49,9 @@ class ProxyPingListener(
         // player list (hover text)
         if (!isLocalPing) {
             val players = event.ping.players.getOrNull()
-            val onlinePlayers = players?.online ?: 0
-            val realMax = players?.max ?: 0
+            val playerCountHandler = proxyPlugin.playerCountHandler
+            val onlinePlayers = playerCountHandler.onlinePlayersOr(players?.online ?: 0)
+            val realMax = playerCountHandler.maxPlayersOr(players?.max ?: 0)
 
             val samplePlayers: List<SamplePlayer> = if (layout.playerList.enabled && layout.playerList.entries.isNotEmpty()) {
                 layout.playerList.entries.map { SamplePlayer(it, UUID.randomUUID()) }

--- a/proxy-velocity/src/main/resources/config/config.yml
+++ b/proxy-velocity/src/main/resources/config/config.yml
@@ -33,6 +33,21 @@ whitelist:
     - Notch
 
 # ───────────────────────────────────────────────────────────────────────────────
+# Player Count
+# Displays the summed player count for this proxy group and optional extra targets.
+#
+# Read more @ https://docs.simplecloud.app/manual/plugins/proxy-essentials
+# ───────────────────────────────────────────────────────────────────────────────
+
+player-count:
+  # Additional SimpleCloud groups included in the displayed player count.
+  additional-groups: []
+  # Persistent servers included in the displayed player count.
+  additional-persistent-servers: []
+  # Player count update interval in ticks.
+  update-time: 20
+
+# ───────────────────────────────────────────────────────────────────────────────
 # Tablist
 # Configures tablist layouts and update intervals for connected players.
 #

--- a/proxy-velocity/src/main/resources/config/config.yml
+++ b/proxy-velocity/src/main/resources/config/config.yml
@@ -40,11 +40,13 @@ whitelist:
 # ───────────────────────────────────────────────────────────────────────────────
 
 player-count:
+  # Enables summed player counts for the server list and placeholders.
+  enabled: true
   # Additional SimpleCloud groups included in the displayed player count.
   additional-groups: []
   # Persistent servers included in the displayed player count.
   additional-persistent-servers: []
-  # Player count update interval in ticks.
+  # Player count update interval in ticks. Set to 0 to disable automatic updates.
   update-time: 20
 
 # ───────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What this pull request does

This pull request adds configurable Player Count support to Proxy Essentials. Instead of only showing the local proxy's current player count, the plugin can now calculate a summed count from the current SimpleCloud group and optional additional targets.

The new `player-count` configuration allows server owners to include extra SimpleCloud groups and persistent servers in the displayed online/max player count. That calculated count is then used for server-list ping responses and the default player-count placeholders used by MOTD, tablist, and related text rendering.

## Why this is needed

In a SimpleCloud setup, the visible Minecraft server list count should often represent more than one local proxy instance. Networks may split players across multiple groups or persistent servers, so using only the proxy's direct player count can make the server appear less populated or inconsistent with the actual network state.

This change makes the displayed player count configurable and closer to the intended network-wide view while still preserving the existing local proxy count as a fallback.

## Original changes in this pull request

- Added a new `player-count` section to the default BungeeCord and Velocity configs.
- Added `PlayerCountConfig` to the shared configuration model.
- Added `PlayerCountHandler`, which periodically reads SimpleCloud group/server player counts and stores a snapshot.
- Added Cloud API helper methods for resolving servers by ID and persistent server names.
- Updated BungeeCord and Velocity ping listeners to use the calculated player count.
- Updated placeholder resolver setup so `<online_players>` and related values can use the calculated count.
- Added legacy config migration support for the new player-count defaults.

## Follow-up changes added now

After reviewing the first version, I added a hardening commit to make the feature safer and clearer before merge.

- Added `player-count.enabled` so the summed player-count feature can be explicitly disabled.
- Changed `update-time: 0` to disable automatic syncing instead of being coerced to a 1-tick update loop. This avoids accidental high-frequency Cloud API polling.
- Added an additive config migration pass for existing `config.yml` files, so current installs receive the new `player-count` section or missing `enabled` key even when they are not using the old split config files.
- Updated the default BungeeCord and Velocity config comments to document the new enabled flag and the `update-time: 0` behavior.

These follow-up changes keep the feature behavior predictable for existing users and avoid surprising runtime behavior when the update interval is set to zero.