### PR TITLE
Fix trusted proxy ping source detection

### DIFF
--- a/proxy-bungeecord/src/main/kotlin/app/simplecloud/plugin/proxy/bungeecord/listener/ProxyPingListener.kt
+++ b/proxy-bungeecord/src/main/kotlin/app/simplecloud/plugin/proxy/bungeecord/listener/ProxyPingListener.kt
@@ -3,12 +3,12 @@ package app.simplecloud.plugin.proxy.bungeecord.listener
 import app.simplecloud.plugin.proxy.bungeecord.ProxyBungeeCordPlugin
 import app.simplecloud.plugin.proxy.shared.config.motd.MaxPlayerDisplayType
 import app.simplecloud.plugin.proxy.shared.handler.ServerIconLoader
+import app.simplecloud.plugin.proxy.shared.handler.TrustedPingSourceMatcher
 import net.md_5.bungee.api.Favicon
 import net.md_5.bungee.api.ServerPing.*
 import net.md_5.bungee.api.event.ProxyPingEvent
 import net.md_5.bungee.api.plugin.Listener
 import net.md_5.bungee.event.EventHandler
-import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.nio.file.Path
 import java.util.*
@@ -20,6 +20,11 @@ class ProxyPingListener(
     private val serverIconLoader = ServerIconLoader(
         Path.of(plugin.proxyPlugin.serverIconsPath)
     ) { image -> Favicon.create(image) }
+
+    private val trustedPingSourceMatcher = TrustedPingSourceMatcher(
+        { plugin.proxyPlugin.proxyEssentialsConfig.get().trustedPingSources },
+        { plugin.logger.warning(it) }
+    )
 
     @EventHandler
     fun onPing(event: ProxyPingEvent) {
@@ -35,9 +40,7 @@ class ProxyPingListener(
         response.descriptionComponent = net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer.get().serialize(motd)[0]
 
         val socketAddress = event.connection.socketAddress as? InetSocketAddress
-        val remoteAddress = socketAddress?.address?.hostAddress ?: ""
-        val localAddress = InetAddress.getLocalHost().hostAddress
-        val isLocalPing = remoteAddress == localAddress
+        val isTrustedPing = trustedPingSourceMatcher.isTrusted(socketAddress?.address)
 
         // server icon
         if (layout.serverIcon.enabled) {
@@ -45,7 +48,7 @@ class ProxyPingListener(
                 ?.let { response.setFavicon(it) }
         }
 
-        if (!isLocalPing) {
+        if (!isTrustedPing) {
             // player list (hover text)
             val samplePlayers = if (layout.playerList.enabled && layout.playerList.entries.isNotEmpty()) {
                 layout.playerList.entries.map { PlayerInfo(it, UUID.randomUUID()) }.toTypedArray()

--- a/proxy-bungeecord/src/main/resources/config/config.yml
+++ b/proxy-bungeecord/src/main/resources/config/config.yml
@@ -32,6 +32,11 @@ whitelist:
   players:
     - Notch
 
+# Internal ping sources that should keep the proxy's real player count response.
+# Local interface addresses are detected automatically. Add CIDR ranges here only
+# when another trusted internal host pings this proxy, for example 192.168.102.10/32.
+trusted-ping-sources: []
+
 # ───────────────────────────────────────────────────────────────────────────────
 # Tablist
 # Configures tablist layouts and update intervals for connected players.

--- a/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/config/ProxyEssentialsConfig.kt
+++ b/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/config/ProxyEssentialsConfig.kt
@@ -25,6 +25,7 @@ data class ProxyEssentialsConfig(
         )
     ),
     val whitelist: WhitelistConfig = WhitelistConfig(),
+    @Setting("trusted-ping-sources") val trustedPingSources: List<String> = emptyList(),
     val tablist: List<TabListGroup> = listOf(
         TabListGroup(
             name = "global",

--- a/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/handler/TrustedPingSourceMatcher.kt
+++ b/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/handler/TrustedPingSourceMatcher.kt
@@ -1,0 +1,100 @@
+package app.simplecloud.plugin.proxy.shared.handler
+
+import java.net.InetAddress
+import java.net.NetworkInterface
+
+class TrustedPingSourceMatcher(
+    private val trustedSources: () -> List<String>,
+    private val warn: (String) -> Unit
+) {
+    private val localAddresses: Set<InetAddress> by lazy { discoverLocalAddresses() }
+
+    @Volatile
+    private var cachedSourceEntries: List<String> = emptyList()
+
+    @Volatile
+    private var cachedRanges: List<TrustedAddressRange> = emptyList()
+
+    fun isTrusted(remoteAddress: InetAddress?): Boolean {
+        if (remoteAddress == null) return false
+        if (remoteAddress.isLoopbackAddress || localAddresses.contains(remoteAddress)) return true
+
+        return ranges().any { it.contains(remoteAddress) }
+    }
+
+    private fun ranges(): List<TrustedAddressRange> {
+        val currentEntries = trustedSources().map { it.trim() }.filter { it.isNotEmpty() }
+        if (currentEntries == cachedSourceEntries) {
+            return cachedRanges
+        }
+
+        val parsedRanges = currentEntries.mapNotNull { entry ->
+            TrustedAddressRange.parse(entry) ?: run {
+                warn("Ignoring invalid trusted ping source '$entry'. Expected an IP address or CIDR range.")
+                null
+            }
+        }
+
+        cachedSourceEntries = currentEntries
+        cachedRanges = parsedRanges
+        return parsedRanges
+    }
+
+    private fun discoverLocalAddresses(): Set<InetAddress> {
+        val addresses = mutableSetOf<InetAddress>()
+
+        runCatching {
+            NetworkInterface.getNetworkInterfaces().asSequence()
+                .filter { it.isUp }
+                .flatMap { it.inetAddresses.asSequence() }
+                .forEach { addresses.add(it) }
+        }.onFailure {
+            warn("Unable to discover local network addresses: ${it.message}")
+        }
+
+        runCatching { addresses.add(InetAddress.getLocalHost()) }
+        addresses.add(InetAddress.getLoopbackAddress())
+
+        return addresses
+    }
+
+    private data class TrustedAddressRange(
+        private val addressBytes: ByteArray,
+        private val prefixLength: Int
+    ) {
+        fun contains(address: InetAddress): Boolean {
+            val candidateBytes = address.address
+            if (candidateBytes.size != addressBytes.size) return false
+
+            val fullBytes = prefixLength / BITS_PER_BYTE
+            val remainingBits = prefixLength % BITS_PER_BYTE
+
+            for (index in 0 until fullBytes) {
+                if (candidateBytes[index] != addressBytes[index]) return false
+            }
+
+            if (remainingBits == 0) return true
+
+            val mask = (0xFF shl (BITS_PER_BYTE - remainingBits)) and 0xFF
+            return (candidateBytes[fullBytes].toInt() and mask) == (addressBytes[fullBytes].toInt() and mask)
+        }
+
+        companion object {
+            private const val BITS_PER_BYTE = 8
+
+            fun parse(entry: String): TrustedAddressRange? {
+                val parts = entry.split('/', limit = 2).map { it.trim() }
+                val address = runCatching { InetAddress.getByName(parts[0]) }.getOrNull() ?: return null
+                val maxPrefixLength = address.address.size * BITS_PER_BYTE
+                val prefixLength = when (parts.size) {
+                    1 -> maxPrefixLength
+                    else -> parts[1].toIntOrNull() ?: return null
+                }
+
+                if (prefixLength !in 0..maxPrefixLength) return null
+
+                return TrustedAddressRange(address.address, prefixLength)
+            }
+        }
+    }
+}

--- a/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/handler/TrustedPingSourceMatcher.kt
+++ b/proxy-shared/src/main/kotlin/app/simplecloud/plugin/proxy/shared/handler/TrustedPingSourceMatcher.kt
@@ -10,10 +10,7 @@ class TrustedPingSourceMatcher(
     private val localAddresses: Set<InetAddress> by lazy { discoverLocalAddresses() }
 
     @Volatile
-    private var cachedSourceEntries: List<String> = emptyList()
-
-    @Volatile
-    private var cachedRanges: List<TrustedAddressRange> = emptyList()
+    private var cachedRanges = TrustedAddressRangeCache()
 
     fun isTrusted(remoteAddress: InetAddress?): Boolean {
         if (remoteAddress == null) return false
@@ -24,8 +21,9 @@ class TrustedPingSourceMatcher(
 
     private fun ranges(): List<TrustedAddressRange> {
         val currentEntries = trustedSources().map { it.trim() }.filter { it.isNotEmpty() }
-        if (currentEntries == cachedSourceEntries) {
-            return cachedRanges
+        val currentCache = cachedRanges
+        if (currentEntries == currentCache.entries) {
+            return currentCache.ranges
         }
 
         val parsedRanges = currentEntries.mapNotNull { entry ->
@@ -35,8 +33,7 @@ class TrustedPingSourceMatcher(
             }
         }
 
-        cachedSourceEntries = currentEntries
-        cachedRanges = parsedRanges
+        cachedRanges = TrustedAddressRangeCache(currentEntries, parsedRanges)
         return parsedRanges
     }
 
@@ -57,6 +54,11 @@ class TrustedPingSourceMatcher(
 
         return addresses
     }
+
+    private data class TrustedAddressRangeCache(
+        val entries: List<String> = emptyList(),
+        val ranges: List<TrustedAddressRange> = emptyList()
+    )
 
     private data class TrustedAddressRange(
         private val addressBytes: ByteArray,
@@ -81,10 +83,12 @@ class TrustedPingSourceMatcher(
 
         companion object {
             private const val BITS_PER_BYTE = 8
+            private val IPV4_REGEX = Regex("""\d{1,3}(?:\.\d{1,3}){3}""")
+            private val IPV6_REGEX = Regex("""[0-9a-fA-F:.]+""")
 
             fun parse(entry: String): TrustedAddressRange? {
                 val parts = entry.split('/', limit = 2).map { it.trim() }
-                val address = runCatching { InetAddress.getByName(parts[0]) }.getOrNull() ?: return null
+                val address = parseLiteralAddress(parts[0]) ?: return null
                 val maxPrefixLength = address.address.size * BITS_PER_BYTE
                 val prefixLength = when (parts.size) {
                     1 -> maxPrefixLength
@@ -94,6 +98,21 @@ class TrustedPingSourceMatcher(
                 if (prefixLength !in 0..maxPrefixLength) return null
 
                 return TrustedAddressRange(address.address, prefixLength)
+            }
+
+            private fun parseLiteralAddress(entry: String): InetAddress? {
+                if (entry.matches(IPV4_REGEX)) {
+                    val octets = entry.split('.').map { it.toInt() }
+                    if (octets.all { it in 0..255 }) {
+                        return InetAddress.getByAddress(octets.map { it.toByte() }.toByteArray())
+                    }
+                }
+
+                if (':' in entry && entry.matches(IPV6_REGEX)) {
+                    return runCatching { InetAddress.getByName(entry) }.getOrNull()
+                }
+
+                return null
             }
         }
     }

--- a/proxy-velocity/src/main/kotlin/app/simplecloud/plugin/proxy/velocity/listener/ProxyPingListener.kt
+++ b/proxy-velocity/src/main/kotlin/app/simplecloud/plugin/proxy/velocity/listener/ProxyPingListener.kt
@@ -3,13 +3,13 @@ package app.simplecloud.plugin.proxy.velocity.listener
 import app.simplecloud.plugin.proxy.shared.ProxyPlugin
 import app.simplecloud.plugin.proxy.shared.config.motd.MaxPlayerDisplayType
 import app.simplecloud.plugin.proxy.shared.handler.ServerIconLoader
+import app.simplecloud.plugin.proxy.shared.handler.TrustedPingSourceMatcher
 import app.simplecloud.plugin.proxy.velocity.ProxyVelocityPlugin
 import com.velocitypowered.api.event.Subscribe
 import com.velocitypowered.api.event.proxy.ProxyPingEvent
 import com.velocitypowered.api.proxy.server.ServerPing
 import com.velocitypowered.api.proxy.server.ServerPing.SamplePlayer
 import com.velocitypowered.api.util.Favicon
-import java.net.InetAddress
 import java.nio.file.Path
 import java.util.*
 import kotlin.jvm.optionals.getOrNull
@@ -23,6 +23,11 @@ class ProxyPingListener(
         Path.of(proxyPlugin.serverIconsPath)
     ) { image -> Favicon.create(image) }
 
+    private val trustedPingSourceMatcher = TrustedPingSourceMatcher(
+        { proxyPlugin.proxyEssentialsConfig.get().trustedPingSources },
+        { plugin.logger.warn(it) }
+    )
+
     @Subscribe
     fun onProxyPing(event: ProxyPingEvent) {
         val layout = proxyPlugin.motdLayoutHandler.getCurrentMotdLayout()
@@ -34,9 +39,7 @@ class ProxyPingListener(
 
         val motd = plugin.deserializeToComponent("${entry.line1}\n${entry.line2}")
 
-        val remoteAddress = event.connection.remoteAddress.address.hostAddress
-        val localAddress = InetAddress.getLocalHost().hostAddress
-        val isLocalPing = remoteAddress == localAddress
+        val isTrustedPing = trustedPingSourceMatcher.isTrusted(event.connection.remoteAddress.address)
 
         val builder = event.ping.asBuilder().description(motd)
 
@@ -47,7 +50,7 @@ class ProxyPingListener(
         }
 
         // player list (hover text)
-        if (!isLocalPing) {
+        if (!isTrustedPing) {
             val players = event.ping.players.getOrNull()
             val onlinePlayers = players?.online ?: 0
             val realMax = players?.max ?: 0

--- a/proxy-velocity/src/main/resources/config/config.yml
+++ b/proxy-velocity/src/main/resources/config/config.yml
@@ -32,6 +32,11 @@ whitelist:
   players:
     - Notch
 
+# Internal ping sources that should keep the proxy's real player count response.
+# Local interface addresses are detected automatically. Add CIDR ranges here only
+# when another trusted internal host pings this proxy, for example 192.168.102.10/32.
+trusted-ping-sources: []
+
 # ───────────────────────────────────────────────────────────────────────────────
 # Tablist
 # Configures tablist layouts and update intervals for connected players.


### PR DESCRIPTION
## Why

A local SimpleCloud/system ping is used to read the real player count for the current proxy. The previous detection only compared the remote ping address with `InetAddress.getLocalHost()`, which misses valid internal bindings such as `192.168.102.10`. When that detection fails, the MOTD slot/player-count rewriting is applied to the internal ping response, so the cloud sees the combined proxy count as if it belonged to each proxy. In multi-proxy setups this can make the network appear full too early and prevent joins.

## What changed

- Added a shared `TrustedPingSourceMatcher` used by both Velocity and BungeeCord ping listeners.
- Treats loopback addresses and addresses assigned to local network interfaces as trusted automatically.
- Added optional `trusted-ping-sources` config entries supporting exact IPs and CIDR ranges for deployments where another trusted internal host performs the ping.
- Kept the default config value empty, so existing configs remain valid and behavior is backward compatible aside from correctly recognizing more local/internal self-pings.
- Existing `/scproxy reload` behavior can pick up changed trusted source entries because listeners read the config through the existing config provider.

## Compatibility

This is intentionally additive:

- Existing config files do not need to be changed.
- Existing loopback/self-ping behavior still works.
- Public player pings still receive the configured MOTD player-list, slot, and version-name behavior unless their source is local or explicitly trusted.

## Verification

- `sh gradlew build`
